### PR TITLE
fix!: non-helpful max inlines error messages

### DIFF
--- a/src/test/ArbitraryDerivingSuite.scala
+++ b/src/test/ArbitraryDerivingSuite.scala
@@ -57,7 +57,7 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
   }
 
   // not a hard requirement (just guarding against accidental worsening by refactoring)
-  test("supports case classes with up to 28 fields (if -Xmax-inlines=32)") {
+  test("supports case classes with up to 27 fields (if -Xmax-inlines=32)") {
     summon[Arbitrary[MaxCaseClass]]
   }
 

--- a/src/test/test_classes.scala
+++ b/src/test/test_classes.scala
@@ -167,7 +167,7 @@ case class MaxCaseClass(
   a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int, i1: Int, j1: Int,
   k1: Int, l1: Int, m1: Int, n1: Int, o1: Int, p1: Int, q1: Int, r1: Int, s1: Int, t1: Int,
   u1: Int, v1: Int, w1: Int, x1: Int, y1: Int, z1: Int,
-  a2: Int, b2: Int
+  a2: Int
 )
 // format: on
 


### PR DESCRIPTION
Refactor derivation of Arbitrary-instances so that it is (much) more likely that in case of "Maximal number of successive inlines exceeded", the compiler error message will be the expected one.

This change is somewhat breaking as it increases the inlining steps for products by one, so it slightly reduces the threshold for hitting that limit. (This could have been avoided at the price of writing redundant code, but that didn't seem worth it.)