### PR TITLE
feat!: support for recursive structures

### DIFF
--- a/src/main/derived/CogenDeriving.scala
+++ b/src/main/derived/CogenDeriving.scala
@@ -1,7 +1,6 @@
 package io.github.martinhh.derived
 
 import scala.compiletime.erasedValue
-import scala.compiletime.summonAll
 import scala.compiletime.summonInline
 import scala.compiletime.summonFrom
 import scala.deriving.*
@@ -10,9 +9,26 @@ import org.scalacheck.Cogen
 
 trait CogenDeriving:
 
+  private inline def summonSumInstances[T, Elems <: Tuple]: List[Cogen[T]] =
+    inline erasedValue[Elems] match
+      case _: (elem *: elems) =>
+        deriveOrSummonSumInstance[T, elem].asInstanceOf[Cogen[T]] :: summonSumInstances[T, elems]
+      case _: EmptyTuple =>
+        Nil
+
+  private inline def deriveOrSummonSumInstance[T, Elem]: Cogen[Elem] =
+    inline erasedValue[Elem] match
+      case _: T =>
+        inline erasedValue[T] match
+          case _: Elem =>
+            endlessRecursionError
+          case _ =>
+            deriveCogen[Elem](using summonInline[Mirror.Of[Elem]])
+      case _ =>
+        summonInline[Cogen[Elem]]
+
   private inline def cogenSum[T](s: Mirror.SumOf[T]): Cogen[T] =
-    val elems = summonAll[Tuple.Map[s.MirroredElemTypes, Cogen]]
-    val vec = elems.toList.toVector
+    lazy val vec = summonSumInstances[T, s.MirroredElemTypes].toVector
     Cogen { (seed, t) =>
       val i = s.ordinal(t)
       given Cogen[t.type] = vec(i).asInstanceOf[Cogen[t.type]]
@@ -24,7 +40,7 @@ trait CogenDeriving:
   private inline def cogenTuple[T <: Tuple]: Cogen[T] =
     inline erasedValue[T] match
       case _: (t *: ts) =>
-        val cogentT = summonInline[Cogen[t]]
+        val cogentT = anyGivenCogen[t]
         given Cogen[ts] = cogenTuple[ts]
         Cogen[t *: ts] { (seed, pair) =>
           Cogen.perturb[ts](Cogen.perturb[t](seed, pair.head)(cogentT), pair.tail)
@@ -36,13 +52,13 @@ trait CogenDeriving:
     cogenTuple[p.MirroredElemTypes].contramap[T](productToMirroredElemTypes(p)(_))
 
   inline def deriveCogen[T](using m: Mirror.Of[T]): Cogen[T] =
-    inline m match
+    given cogen: Cogen[T] = inline m match
       case s: Mirror.SumOf[T]     => cogenSum(s)
       case p: Mirror.ProductOf[T] => cogenProduct(p)
+    cogen
 
   inline given anyGivenCogen[T]: Cogen[T] =
     summonFrom {
-      case c: Cogen[T]            => c
-      case s: Mirror.SumOf[T]     => cogenSum(s)
-      case p: Mirror.ProductOf[T] => cogenProduct(p)
+      case c: Cogen[T]     => c
+      case s: Mirror.Of[T] => deriveCogen(using s)
     }

--- a/src/main/derived/ShrinkDeriving.scala
+++ b/src/main/derived/ShrinkDeriving.scala
@@ -1,8 +1,8 @@
 package io.github.martinhh.derived
 
 import scala.compiletime.constValue
+import scala.compiletime.erasedValue
 import scala.compiletime.ops.int.S
-import scala.compiletime.summonAll
 import scala.compiletime.summonInline
 import scala.compiletime.summonFrom
 import scala.deriving.*
@@ -11,9 +11,26 @@ import org.scalacheck.Shrink
 @annotation.nowarn("msg=Stream .* is deprecated")
 private trait ShrinkDeriving:
 
+  private inline def summonSumInstances[T, Elems <: Tuple]: List[Shrink[T]] =
+    inline erasedValue[Elems] match
+      case _: (elem *: elems) =>
+        deriveOrSummonSumInstance[T, elem].asInstanceOf[Shrink[T]] :: summonSumInstances[T, elems]
+      case _: EmptyTuple =>
+        Nil
+
+  private inline def deriveOrSummonSumInstance[T, Elem]: Shrink[Elem] =
+    inline erasedValue[Elem] match
+      case _: T =>
+        inline erasedValue[T] match
+          case _: Elem =>
+            endlessRecursionError
+          case _ =>
+            deriveShrink[Elem](using summonInline[Mirror.Of[Elem]])
+      case _ =>
+        summonInline[Shrink[Elem]]
+
   private inline def shrinkSum[T](s: Mirror.SumOf[T]): Shrink[T] =
-    val elems = summonAll[Tuple.Map[s.MirroredElemTypes, Shrink]]
-    val vec = elems.toList.toVector
+    lazy val vec = summonSumInstances[T, s.MirroredElemTypes].toVector
     Shrink { t =>
       val i = s.ordinal(t)
       vec(i).asInstanceOf[Shrink[t.type]].shrink(t)
@@ -31,7 +48,7 @@ private trait ShrinkDeriving:
     if (i >= size) {
       acc
     } else {
-      val shrinkI = summonInline[Shrink[Tuple.Elem[T, I]]]
+      val shrinkI = anyGivenShrink[Tuple.Elem[T, I]]
       val elemI: Tuple.Elem[T, I] = t.asInstanceOf[NonEmptyTuple](i).asInstanceOf[Tuple.Elem[T, I]]
       val newAcc = acc.lazyAppendedAll(shrinkI.shrink(elemI).map(ei => replaceElemI[I, T](t, ei)))
       buildShrinkTuple[S[I], T](size, t, newAcc)
@@ -47,13 +64,22 @@ private trait ShrinkDeriving:
     Shrink.xmap[p.MirroredElemTypes, T](p.fromTuple(_), productToMirroredElemTypes(p)(_))
 
   inline def deriveShrink[T](using m: Mirror.Of[T]): Shrink[T] =
-    inline m match
+    given shrink: Shrink[T] = inline m match
       case s: Mirror.SumOf[T]     => shrinkSum(s)
       case p: Mirror.ProductOf[T] => shrinkProduct(p)
+    shrink
 
   inline given anyGivenShrink[T]: Shrink[T] =
     summonFrom {
-      case s: Shrink[T] if !isShrinkAnyMacro[T] => s
-      case s: Mirror.SumOf[T]                   => shrinkSum(s)
-      case p: Mirror.ProductOf[T]               => shrinkProduct(p)
+      case s: Shrink[T] if !isShrinkAnyMacro[T] =>
+        s
+      // both cases below are coded out (instead of just delegating to deriveShrink) because
+      // Shrink-derivation already is the longest (thus critical) path for inlining (and hitting
+      // the "Xmaxinline" limit) in the whole library
+      case s: Mirror.SumOf[T] =>
+        given shrink: Shrink[T] = shrinkSum(s)
+        shrink
+      case p: Mirror.ProductOf[T] =>
+        given shrink: Shrink[T] = shrinkProduct(p)
+        shrink
     }

--- a/src/main/derived/derived.scala
+++ b/src/main/derived/derived.scala
@@ -1,8 +1,12 @@
 package io.github.martinhh.derived
 
+import scala.compiletime.error
 import scala.deriving.Mirror
 
 private inline def productToMirroredElemTypes[T](p: Mirror.ProductOf[T])(
   t: T
 ): p.MirroredElemTypes =
   Tuple.fromProduct(t.asInstanceOf[Product]).asInstanceOf[p.MirroredElemTypes]
+
+// should be impossible to reach (called in case Mirror.SumOf[T].MirroredElemTypes contains T)
+private inline def endlessRecursionError: Nothing = error("infinite recursive derivation")

--- a/src/test/ArbitraryDerivingSuite.scala
+++ b/src/test/ArbitraryDerivingSuite.scala
@@ -1,5 +1,6 @@
 package io.github.martinhh
 
+import org.scalacheck
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Gen.Parameters
@@ -18,10 +19,16 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
       seed.next
     }
 
-  test("deriveArb allows to derive a given without loop of given definition") {
+  test("deriveArbitrary allows to derive a given without loop of given definition") {
     given arb: Arbitrary[SimpleCaseClass] = derived.arbitrary.deriveArbitrary
     // proven if it compiles, but let's do some run-time testing anyway:
     equalValues(SimpleCaseClass.expectedGen, nTests = 10)(using arb)
+  }
+
+  test("deriveArbitrary supports recursive structures") {
+    equalValues(RecursiveList.expectedGen[Int])(using derived.arbitrary.deriveArbitrary)
+    equalValues(NestedSumsRecursiveList.expectedGen[Int])(using derived.arbitrary.deriveArbitrary)
+    equalValues(MaybeMaybeList.expectedGen[Int])(using derived.arbitrary.deriveArbitrary)
   }
 
   import io.github.martinhh.derived.arbitrary.given
@@ -63,12 +70,24 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
     equalValues(HasMemberThatHasGivenInstances.expectedGen)
   }
 
+  test("supports recursive structures") {
+    equalValues(RecursiveList.expectedGen[Int])
+  }
+
+  test("supports recursive structures (across nested sealed traits)") {
+    equalValues(NestedSumsRecursiveList.expectedGen[Int])
+  }
+
+  test("supports recursive structures (across more complex nested structures)") {
+    equalValues(MaybeMaybeList.expectedGen[Int])
+  }
+
   // not a hard requirement (just guarding against accidental worsening by refactoring)
-  test("supports case classes with up to 27 fields (if -Xmax-inlines=32)") {
+  test("supports case classes with up to 26 fields (if -Xmax-inlines=32)") {
     summon[Arbitrary[MaxCaseClass]]
   }
 
   // not a hard requirement (just guarding against accidental worsening by refactoring)
-  test("supports enums with up to 25 members (if -Xmax-inlines=32)") {
+  test("supports enums with up to 24 members (if -Xmax-inlines=32)") {
     summon[Arbitrary[MaxEnum]]
   }

--- a/src/test/CogenDerivingSuite.scala
+++ b/src/test/CogenDerivingSuite.scala
@@ -25,6 +25,18 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
     equalValues(SimpleCaseClass.expectedCogen)
   }
 
+  test("deriveCogen supports recursive structures") {
+    import derived.scalacheck.anyGivenArbitrary
+    import derived.scalacheck.deriveCogen
+    equalValues(RecursiveList.expectedCogen[Int])(using arbSeed, anyGivenArbitrary, deriveCogen)
+    equalValues(NestedSumsRecursiveList.expectedCogen[Int])(
+      using arbSeed,
+      anyGivenArbitrary,
+      deriveCogen
+    )
+    equalValues(MaybeMaybeList.expectedCogen[Int])(using arbSeed, anyGivenArbitrary, deriveCogen)
+  }
+
   import derived.scalacheck.given
 
   property("perturbs to same seeds as non-derived expected Cogen (for simple ADT)") {
@@ -49,6 +61,18 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
     equalValues(HasMemberThatHasGivenInstances.expectedCogen)
   }
 
+  test("given derivation supports recursive structures") {
+    equalValues(RecursiveList.expectedCogen[Int])
+  }
+
+  test("given derivation supports recursive structures (across nested sealed traits)") {
+    equalValues(NestedSumsRecursiveList.expectedCogen[Int])
+  }
+
+  test("given derivation supports recursive structures (across more complex nested structures)") {
+    equalValues(MaybeMaybeList.expectedCogen[Int])
+  }
+
   test("enables derivation of Arbitrary instances for functions") {
     val arbFunction1: Arbitrary[ComplexADTWithNestedMembers => ABC] =
       summon
@@ -58,12 +82,12 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
   }
 
   // (should support as least as many fields as ArbitraryDeriving)
-  test("supports case classes with up to 27 fields (if -Xmax-inlines=32)") {
+  test("supports case classes with up to 26 fields (if -Xmax-inlines=32)") {
     summon[Cogen[MaxCaseClass]]
   }
 
   // (should support as least as many fields as ArbitraryDeriving)
-  test("supports enums with up to 25 members (if -Xmax-inlines=32)") {
+  test("supports enums with up to 24 members (if -Xmax-inlines=32)") {
     summon[Cogen[MaxEnum]]
   }
 

--- a/src/test/test_classes.scala
+++ b/src/test/test_classes.scala
@@ -6,6 +6,17 @@ import org.scalacheck.Cogen
 import org.scalacheck.Cogen.perturb
 import org.scalacheck.Gen
 import org.scalacheck.Shrink
+import org.scalacheck.rng.Seed
+
+// helper for defining expected Cogens
+private def perturbSingletonInSum[T](ordinal: Int, seed: Seed, value: T) =
+  perturb(
+    perturb[T](
+      seed,
+      value
+    )(Cogen.cogenUnit.contramap(_ => ())),
+    ordinal
+  )
 
 sealed trait SimpleADT
 
@@ -17,13 +28,7 @@ object SimpleADT:
     Cogen { (seed, value) =>
       value match
         case SimpleCaseObject =>
-          perturb(
-            perturb[SimpleCaseObject.type](
-              seed,
-              SimpleCaseObject
-            )(SimpleCaseObject.expectedCogen),
-            0
-          )
+          perturbSingletonInSum(0, seed, SimpleCaseObject)
         case cc: SimpleCaseClass =>
           perturb(
             perturb[SimpleCaseClass](
@@ -43,9 +48,7 @@ object SimpleADT:
         SimpleCaseClass.expectedShrink.shrink(scc)
     }
 
-case object SimpleCaseObject extends SimpleADT:
-  val expectedCogen: Cogen[SimpleCaseObject.type] =
-    Cogen.cogenUnit.contramap(_ => ())
+case object SimpleCaseObject extends SimpleADT
 
 case class SimpleCaseClass(x: Int, y: String, z: Double) extends SimpleADT
 
@@ -224,15 +227,270 @@ object HasMemberThatHasGivenInstances:
   val expectedShrink: Shrink[HasMemberThatHasGivenInstances] =
     Shrink.xmap(HasMemberThatHasGivenInstances.apply, _.member)
 
+// A simple list as most basic test for recursive structures
+enum RecursiveList[+T]:
+  case Cns(t: T, ts: RecursiveList[T])
+  case Nl
+
+object RecursiveList:
+  def expectedGen[T](using arbT: Arbitrary[T]): Gen[RecursiveList[T]] =
+    Gen.oneOf(
+      for {
+        t <- arbT.arbitrary
+        ts <- expectedGen[T]
+      } yield Cns(t, ts),
+      Gen.const(Nl)
+    )
+  def expectedCogen[T](using cogenT: Cogen[T]): Cogen[RecursiveList[T]] =
+    Cogen { (seed, value) =>
+      value match
+        case c: Cns[T] =>
+          perturb(
+            perturb[Cns[T]](
+              seed,
+              c
+            )(Cogen { (seed, value) =>
+              perturb[Unit](
+                perturb[RecursiveList[T]](
+                  perturb[T](
+                    seed,
+                    value.t
+                  ),
+                  value.ts
+                )(expectedCogen),
+                ()
+              )
+            }),
+            0
+          )
+        case Nl =>
+          perturbSingletonInSum(1, seed, Nl)
+    }
+
+  @annotation.nowarn("msg=Stream .* is deprecated")
+  def expectedShrink[T](using shrinkT: Shrink[T]): Shrink[RecursiveList[T]] =
+    Shrink {
+      case c: Cns[T] =>
+        Shrink
+          .xmap[(T, RecursiveList[T]), Cns[T]](
+            { case (t, ts) => Cns(t, ts) },
+            cns => (cns.t, cns.ts)
+          )(Shrink.shrinkTuple2(shrinkT, expectedShrink))
+          .shrink(c)
+      case Nl => Stream.empty
+    }
+
+// A list with an intermediate "nested" sealed trait (to test that nested sealed traits do not
+// break support for recursion in sum types)
+sealed trait NestedSumsRecursiveList[+T]
+object NestedSumsRecursiveList:
+
+  sealed trait NotNl[+T] extends NestedSumsRecursiveList[T]
+  case class Cns[+T](t: T, ts: NestedSumsRecursiveList[T]) extends NotNl[T]
+  case object Nl extends NestedSumsRecursiveList[Nothing]
+
+  def expectedGen[T](using arbT: Arbitrary[T]): Gen[NestedSumsRecursiveList[T]] =
+    Gen.oneOf(
+      for {
+        t <- arbT.arbitrary
+        ts <- expectedGen[T]
+      } yield Cns(t, ts),
+      Gen.const(Nl)
+    )
+
+  def expectedCogen[T](using cogenT: Cogen[T]): Cogen[NestedSumsRecursiveList[T]] =
+    Cogen { (seed, value) =>
+      value match
+        case c: Cns[T] =>
+          perturb(
+            perturb(
+              perturb[Cns[T]](
+                seed,
+                c
+              )(Cogen { (seed, value) =>
+                perturb[Unit](
+                  perturb[NestedSumsRecursiveList[T]](
+                    perturb[T](
+                      seed,
+                      value.t
+                    ),
+                    value.ts
+                  )(expectedCogen),
+                  ()
+                )
+              }),
+              0 // ordinal of Cns within NotNl
+            ),
+            0 // ordinal of NotNl within NestedSumsRecursiveList
+          )
+        case Nl =>
+          perturbSingletonInSum(1, seed, Nl)
+    }
+
+  @annotation.nowarn("msg=Stream .* is deprecated")
+  def expectedShrink[T](using shrinkT: Shrink[T]): Shrink[NestedSumsRecursiveList[T]] =
+    Shrink {
+      case c: Cns[T] =>
+        Shrink
+          .xmap[(T, NestedSumsRecursiveList[T]), Cns[T]](
+            { case (t, ts) => Cns(t, ts) },
+            cns => (cns.t, cns.ts)
+          )(Shrink.shrinkTuple2(shrinkT, expectedShrink))
+          .shrink(c)
+      case Nl => Stream.empty
+    }
+
+// an option-like type
+enum Maybe[+T]:
+  case Defined(t: T)
+  case Undefined
+
+object Maybe:
+  def expectedGen[T](using arbT: Arbitrary[T]): Gen[Maybe[T]] =
+    Gen.oneOf(
+      arbT.arbitrary.map(Defined.apply),
+      Gen.const(Undefined)
+    )
+
+  def expectedCogen[T](using cogenT: Cogen[T]): Cogen[Maybe[T]] =
+    Cogen { (seed, value) =>
+      value match
+        case d: Defined[T] =>
+          perturb(
+            perturb[Defined[T]](
+              seed,
+              d
+            )(Cogen { (seed, value) =>
+              perturb[Unit](
+                perturb[T](
+                  seed,
+                  value.t
+                ),
+                ()
+              )
+            }),
+            0
+          )
+        case Undefined =>
+          perturbSingletonInSum(1, seed, Undefined)
+    }
+
+  @annotation.nowarn("msg=Stream .* is deprecated")
+  def expectedShrink[T](shrinkT: => Shrink[T]): Shrink[Maybe[T]] =
+    Shrink {
+      case d: Defined[T] =>
+        Shrink
+          .xmap[T, Defined[T]](
+            Defined.apply,
+            _.t
+          )(shrinkT)
+          .shrink(d)
+      case Undefined => Stream.empty
+    }
+
+// another option-like type (for the sake of having a more complex example)
+sealed trait MaybeMaybe[+T]
+
+object MaybeMaybe:
+  case class IsMaybe[+T](maybe: Maybe[T]) extends MaybeMaybe[T]
+  case object IsNotMaybe extends MaybeMaybe[Nothing]
+
+  def expectedGen[T](using arbT: Arbitrary[T]): Gen[MaybeMaybe[T]] =
+    Gen.oneOf(
+      Maybe.expectedGen[T].map(IsMaybe.apply),
+      Gen.const(IsNotMaybe)
+    )
+
+  def expectedCogen[T](using cogenT: Cogen[T]): Cogen[MaybeMaybe[T]] =
+    Cogen { (seed, value) =>
+      value match
+        case d: IsMaybe[T] =>
+          perturb(
+            perturb[IsMaybe[T]](
+              seed,
+              d
+            )(Cogen { (seed, value) =>
+              perturb[Unit](
+                perturb[Maybe[T]](
+                  seed,
+                  value.maybe
+                )(Maybe.expectedCogen[T]),
+                ()
+              )
+            }),
+            0
+          )
+        case IsNotMaybe =>
+          perturbSingletonInSum(1, seed, IsNotMaybe)
+    }
+
+  @annotation.nowarn("msg=Stream .* is deprecated")
+  def expectedShrink[T](shrinkT: => Shrink[T]): Shrink[MaybeMaybe[T]] =
+    Shrink {
+      case d: IsMaybe[T] =>
+        Shrink
+          .xmap[Maybe[T], IsMaybe[T]](
+            IsMaybe.apply,
+            _.maybe
+          )(Maybe.expectedShrink(shrinkT))
+          .shrink(d)
+      case IsNotMaybe => Stream.empty
+    }
+
+// an example of a recursive structure where the actual recursion happens multiple somewhere
+// deeper down the hierarchy of nested sums and products
+case class MaybeMaybeList[+T](head: T, tail: MaybeMaybe[MaybeMaybeList[T]])
+
+object MaybeMaybeList:
+  def expectedGen[T](using arbT: Arbitrary[T]): Gen[MaybeMaybeList[T]] =
+    given arbTail: Arbitrary[MaybeMaybeList[T]] = Arbitrary(expectedGen)
+    for {
+      head <- arbT.arbitrary
+      tail <- MaybeMaybe.expectedGen[MaybeMaybeList[T]]
+    } yield MaybeMaybeList(head, tail)
+
+  def expectedCogen[T](using cogenT: Cogen[T]): Cogen[MaybeMaybeList[T]] =
+    Cogen { (seed, value) =>
+      perturb[Unit](
+        perturb[MaybeMaybe[MaybeMaybeList[T]]](
+          perturb[T](
+            seed,
+            value.head
+          ),
+          value.tail
+        )(MaybeMaybe.expectedCogen[MaybeMaybeList[T]](using expectedCogen)),
+        ()
+      )
+    }
+
+  def expectedShrink[T](using shrinkT: Shrink[T]): Shrink[MaybeMaybeList[T]] =
+    lazy val shrinkTuple: Shrink[(T, MaybeMaybe[MaybeMaybeList[T]])] =
+      Shrink.shrinkTuple2(shrinkT, MaybeMaybe.expectedShrink(expectedShrink))
+    Shrink.xmap[(T, MaybeMaybe[MaybeMaybeList[T]]), MaybeMaybeList[T]](
+      { case (head, tail) => MaybeMaybeList(head, tail) },
+      mml => (mml.head, mml.tail)
+    )(shrinkTuple)
+
 // format: off
 case class MaxCaseClass(
   a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int, i1: Int, j1: Int,
   k1: Int, l1: Int, m1: Int, n1: Int, o1: Int, p1: Int, q1: Int, r1: Int, s1: Int, t1: Int,
-  u1: Int, v1: Int, w1: Int, x1: Int, y1: Int, z1: Int,
-  a2: Int
+  u1: Int, v1: Int, w1: Int, x1: Int, y1: Int, z1: Int
 )
 // format: on
 
 enum MaxEnum:
   case A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1, P1, Q1, R1, S1, T1, U1, V1,
-    W1, X1, Y1
+    W1, X1
+
+// format: off
+case class MaxShrinkableCaseClass(
+  a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int, i1: Int, j1: Int,
+  k1: Int, l1: Int, m1: Int, n1: Int, o1: Int, p1: Int, q1: Int, r1: Int, s1: Int, t1: Int,
+  u1: Int, v1: Int, w1: Int, x1: Int, y1: Int
+)
+// format: on
+
+enum MaxShrinkableEnum:
+  case A1, B1, C1, D1, E1, F1, G1, H1, I1, J1, K1, L1, M1, N1, O1, P1, Q1, R1, S1, T1, U1, V1,
+    W1


### PR DESCRIPTION
This is somewhat breaking because it adds 1-2 further inlining step(s) to derivation (1 for Arbitrary and Cogen, 2 for Shrink), thus increasing the risk to hit Xmaxinlines.