### PR TITLE
fix: direct recursion

### DIFF
--- a/src/test/ArbitraryDerivingSuite.scala
+++ b/src/test/ArbitraryDerivingSuite.scala
@@ -82,6 +82,10 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
     equalValues(MaybeMaybeList.expectedGen[Int])
   }
 
+  test("supports direct recursion)") {
+    equalValues(DirectRecursion.expectedGen)
+  }
+
   // not a hard requirement (just guarding against accidental worsening by refactoring)
   test("supports case classes with up to 26 fields (if -Xmax-inlines=32)") {
     summon[Arbitrary[MaxCaseClass]]

--- a/src/test/CogenDerivingSuite.scala
+++ b/src/test/CogenDerivingSuite.scala
@@ -73,6 +73,10 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
     equalValues(MaybeMaybeList.expectedCogen[Int])
   }
 
+  test("given derivation supports direct recursion") {
+    equalValues(DirectRecursion.expectedCogen)
+  }
+
   test("enables derivation of Arbitrary instances for functions") {
     val arbFunction1: Arbitrary[ComplexADTWithNestedMembers => ABC] =
       summon

--- a/src/test/ShrinkDerivingSuite.scala
+++ b/src/test/ShrinkDerivingSuite.scala
@@ -71,6 +71,10 @@ class ShrinkDerivingSuite extends munit.ScalaCheckSuite:
     equalValues(MaybeMaybeList.expectedShrink[Int])
   }
 
+  property("supports direct recursion") {
+    equalValues(DirectRecursion.expectedShrink)
+  }
+
   // seems there is no feasible way to get up to par with ArbitraryDeriving, so this is just a
   // guard against making things even worse
   test("supports case classes with up to 25 fields (if -Xmax-inlines=32)") {


### PR DESCRIPTION
fixes that recursive structures could lead to an infinite loop at runtime if the very first field of a product would recur to the "parent" sum (because of a lack of lazyness).