### PR TITLE
fix: explicit derivation not using some givens

### DIFF
--- a/src/main/derived/ArbitraryDeriving.scala
+++ b/src/main/derived/ArbitraryDeriving.scala
@@ -98,7 +98,11 @@ private trait ArbitraryDeriving:
    *   given Arbitrary[Point] = deriveArbitrary
    * }}}
    */
+  @annotation.nowarn("msg=unused") // needed due to https://github.com/lampepfl/dotty/issues/18564
   inline def deriveArbitrary[T](using m: Mirror.Of[T]): Arbitrary[T] =
+    // make derivation available as given (so that dependencies of factories like
+    // Arbitrary.arbContainer can be derived):
+    import scalacheck.anyGivenArbitrary
     inline m match
       case s: Mirror.SumOf[T] =>
         Arbitrary(Gens.sumInstance(s).gen)

--- a/src/main/derived/CogenDeriving.scala
+++ b/src/main/derived/CogenDeriving.scala
@@ -51,7 +51,9 @@ trait CogenDeriving:
   inline private def cogenProduct[T](p: Mirror.ProductOf[T]): Cogen[T] =
     cogenTuple[p.MirroredElemTypes].contramap[T](productToMirroredElemTypes(p)(_))
 
+  @annotation.nowarn("msg=unused") // needed due to https://github.com/lampepfl/dotty/issues/18564
   inline def deriveCogen[T](using m: Mirror.Of[T]): Cogen[T] =
+    import io.github.martinhh.derived.cogen.anyGivenCogen
     given cogen: Cogen[T] = inline m match
       case s: Mirror.SumOf[T]     => cogenSum(s)
       case p: Mirror.ProductOf[T] => cogenProduct(p)

--- a/src/main/derived/ShrinkDeriving.scala
+++ b/src/main/derived/ShrinkDeriving.scala
@@ -63,7 +63,9 @@ private trait ShrinkDeriving:
       }
     Shrink.xmap[p.MirroredElemTypes, T](p.fromTuple(_), productToMirroredElemTypes(p)(_))
 
+  @annotation.nowarn("msg=unused") // needed due to https://github.com/lampepfl/dotty/issues/18564
   inline def deriveShrink[T](using m: Mirror.Of[T]): Shrink[T] =
+    import io.github.martinhh.derived.shrink.anyGivenShrink
     given shrink: Shrink[T] = inline m match
       case s: Mirror.SumOf[T]     => shrinkSum(s)
       case p: Mirror.ProductOf[T] => shrinkProduct(p)

--- a/src/test/ArbitraryDerivingSuite.scala
+++ b/src/test/ArbitraryDerivingSuite.scala
@@ -31,6 +31,10 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
     equalValues(MaybeMaybeList.expectedGen[Int])(using derived.arbitrary.deriveArbitrary)
   }
 
+  test("deriveArbitrary uses existing given factories (e.g. for Lists)") {
+    equalValues(CaseClassWithListOfCaseClass.expectedGen)(using derived.arbitrary.deriveArbitrary)
+  }
+
   import io.github.martinhh.derived.arbitrary.given
 
   test("Generates same values as non-derived Gen (for simple case class)") {
@@ -68,6 +72,12 @@ class ArbitraryDerivingSuite extends munit.FunSuite:
 
   test("given derivation of child-instances does not take precedence over existing givens") {
     equalValues(HasMemberThatHasGivenInstances.expectedGen)
+  }
+
+  test(
+    "given derivation does not take precedence over existing given factories (e.g. for Lists)"
+  ) {
+    equalValues(CaseClassWithListOfCaseClass.expectedGen)
   }
 
   test("supports recursive structures") {

--- a/src/test/CogenDerivingSuite.scala
+++ b/src/test/CogenDerivingSuite.scala
@@ -37,6 +37,16 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
     equalValues(MaybeMaybeList.expectedCogen[Int])(using arbSeed, anyGivenArbitrary, deriveCogen)
   }
 
+  test("deriveCogen uses existing given factories (e.g. for Lists)") {
+    import derived.scalacheck.anyGivenArbitrary
+    import derived.scalacheck.deriveCogen
+    equalValues(CaseClassWithListOfCaseClass.expectedCogen)(
+      using arbSeed,
+      anyGivenArbitrary,
+      deriveCogen
+    )
+  }
+
   import derived.scalacheck.given
 
   property("perturbs to same seeds as non-derived expected Cogen (for simple ADT)") {
@@ -59,6 +69,12 @@ class CogenDerivingSuite extends munit.ScalaCheckSuite:
 
   test("given derivation of child-instances does not take precedence over existing givens") {
     equalValues(HasMemberThatHasGivenInstances.expectedCogen)
+  }
+
+  test(
+    "given derivation does not take precedence over existing given factories (e.g. for Lists)"
+  ) {
+    equalValues(CaseClassWithListOfCaseClass.expectedCogen)
   }
 
   test("given derivation supports recursive structures") {

--- a/src/test/ShrinkDerivingSuite.scala
+++ b/src/test/ShrinkDerivingSuite.scala
@@ -37,6 +37,13 @@ class ShrinkDerivingSuite extends munit.ScalaCheckSuite:
     )
   }
 
+  test("deriveShrink uses existing given factories (e.g. for Lists)") {
+    equalValues(CaseClassWithListOfCaseClass.expectedShrink)(
+      using anyGivenArbitrary,
+      derived.shrink.deriveShrink
+    )
+  }
+
   import io.github.martinhh.derived.shrink.given
 
   property("shrinks to the same values as non-derived expected Shrink (for simple case class)") {
@@ -57,6 +64,12 @@ class ShrinkDerivingSuite extends munit.ScalaCheckSuite:
 
   property("given derivation of child-instances does not take precedence over existing givens") {
     equalValues(HasMemberThatHasGivenInstances.expectedShrink)
+  }
+
+  test(
+    "given derivation does not take precedence over existing given factories (e.g. for Lists)"
+  ) {
+    equalValues(CaseClassWithListOfCaseClass.expectedShrink)
   }
 
   property("supports recursive structures") {


### PR DESCRIPTION
Fixes that the explicit derivation functions (`deriveArbitrary`, `deriveCogen`, `deriveShrink`) would not use existing givens if those depend on a given that needs to be derived (e.g. not using `arbContainer[C, T]` if the required `Arbtrirary[T]` needs to be derived).