### PR TITLE
fix: munit 1.0.0-M10 breaking scala-native tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1.0.2
-      - run: scala-cli --power test .
+      - name: restore cache
+        uses: coursier/cache-action@v6
+      - name: setup scala-cli
+        uses: VirtusLab/scala-cli-setup@v1.0.2
+      - name: test jvm
+        run: scala-cli --power test .
+      - name: test js
+        run: scala-cli --power test --js .
+      - name: test native
+        run: scala-cli --power test --native .
   format:
     runs-on: "ubuntu-latest"
     steps:

--- a/src/test/conf.scala
+++ b/src/test/conf.scala
@@ -1,3 +1,3 @@
 // must be defined here - see https://github.com/VirtusLab/scala-cli/issues/1729
-//> using lib "org.scalameta::munit::1.0.0-M10"
-//> using lib "org.scalameta::munit-scalacheck::1.0.0-M10"
+//> using lib "org.scalameta::munit::1.0.0-M8"
+//> using lib "org.scalameta::munit-scalacheck::1.0.0-M8"


### PR DESCRIPTION
Turns out that the tests (which so far were not run in CI for scala-native and scala-js) were broken for scala-native by the bump to munit 1.0.0-M10.
So for now, this downgrades the munit version back to 1.0.0-M9 and enables tests for native and js in CI.