### PR TITLE
chore: move declaration of test-dependencies

### DIFF
--- a/project.scala
+++ b/project.scala
@@ -1,7 +1,10 @@
 //> using scala "3.3.1"
 //> using platform "jvm", "scala-js", "native"
-//> using lib "org.scalacheck::scalacheck::1.17.0"
 //> using jvm "8"
+
+//> using dep "org.scalacheck::scalacheck::1.17.0"
+//> using test.dep "org.scalameta::munit::1.0.0-M10"
+//> using test.dep "org.scalameta::munit-scalacheck::1.0.0-M10"
 
 //> using option "-Xfatal-warnings"
 //> using option "-Wunused:all"

--- a/src/test/conf.scala
+++ b/src/test/conf.scala
@@ -1,3 +1,0 @@
-// must be defined here - see https://github.com/VirtusLab/scala-cli/issues/1729
-//> using lib "org.scalameta::munit::1.0.0-M10"
-//> using lib "org.scalameta::munit-scalacheck::1.0.0-M10"


### PR DESCRIPTION
Now that scala-cli support syntax for declaration of test-dependencies, there's no more need to declare them separately in the test-dir.