### PR TITLE
fix: uneven distribution #79

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -8,8 +8,7 @@ import scala.compiletime.summonFrom
 import scala.compiletime.summonInline
 import scala.deriving.*
 
-private sealed trait Gens[T]:
-  def gen: Gen[T]
+private sealed trait Gens[T]
 
 private case class SumGens[T](gens: List[SingleGen[T]]) extends Gens[T]:
   def gen: Gen[T] = genOneOf(gens.map(_.gen))
@@ -137,9 +136,10 @@ private trait ArbitraryDeriving:
     summonFrom {
       case a: Arbitrary[T] =>
         a
-      case m: Mirror.Of[T] =>
-        // this is a given so that the result of derivation is available during derivation (to
-        // ensure support for recursive structures - this works because givens are lazy)
-        given arb: Arbitrary[T] = Arbitrary(Gens.derive(m).gen)
+      case s: Mirror.SumOf[T] =>
+        given arb: Arbitrary[T] = Arbitrary(Gens.sumInstance(s).gen)
+        arb
+      case p: Mirror.ProductOf[T] =>
+        given arb: Arbitrary[T] = Arbitrary(Gens.productGen(p))
         arb
     }

--- a/core/src/main/scala/io/github/martinhh/derived/macros.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/macros.scala
@@ -22,3 +22,8 @@ private def isShrinkAny[T](using Type[T])(using Quotes): Expr[Boolean] =
  */
 private inline def isShrinkAnyMacro[T]: Boolean =
   ${ isShrinkAny[T] }
+
+private def typeName[A: Type](using Quotes): Expr[String] =
+  Expr(Type.show[A])
+
+private inline def typeNameMacro[A]: String = ${ typeName[A] }

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -87,6 +87,10 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     equalArbitraryValues(DirectRecursion.expectedGen)
   }
 
+  test("even distribution in sealed traits with diamond inheritance".ignore.pending("fix me")) {
+    equalArbitraryValues(SealedDiamond.expectedGen)
+  }
+
   // not a hard requirement (just guarding against accidental worsening by refactoring)
   test("supports case classes with up to 26 fields (if -Xmax-inlines=32)") {
     summon[Arbitrary[MaxCaseClass]]

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -87,7 +87,7 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     equalArbitraryValues(DirectRecursion.expectedGen)
   }
 
-  test("even distribution in sealed traits with diamond inheritance".ignore.pending("fix me")) {
+  test("even distribution in sealed traits with diamond inheritance") {
     equalArbitraryValues(SealedDiamond.expectedGen)
   }
 

--- a/core/src/test/scala/io/github/martinhh/test_classes.scala
+++ b/core/src/test/scala/io/github/martinhh/test_classes.scala
@@ -539,6 +539,17 @@ object DirectRecursion:
       case Stop => Stream.empty
     }
 
+sealed trait SealedDiamond
+
+object SealedDiamond:
+  sealed trait SubtraitA extends SealedDiamond
+  sealed trait SubtraitB extends SealedDiamond
+  case object Foo extends SealedDiamond
+  case object Bar extends SubtraitA with SubtraitB
+
+  def expectedGen: Gen[SealedDiamond] =
+    Gen.oneOf(Gen.const(Bar), Gen.const(Foo))
+
 // format: off
 case class MaxCaseClass(
   a1: Int, b1: Int, c1: Int, d1: Int, e1: Int, f1: Int, g1: Int, h1: Int, i1: Int, j1: Int,


### PR DESCRIPTION
Filter out duplicate instances of Gens that can result from diamond inheritance in sealed trait (which would lead to extra weight on the affected types).

Fixes #79 