### PR TITLE
refactor: rearrange @nowarn

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
@@ -21,7 +21,6 @@ private object ShrinkSumInstanceSummoner
   override protected inline def derive[Elem]: Shrink[Elem] =
     shrink.deriveShrink[Elem](using summonInline[Mirror.Of[Elem]])
 
-@annotation.nowarn("msg=Stream .* is deprecated")
 private trait ShrinkDeriving:
 
   private inline def shrinkSum[T](s: Mirror.SumOf[T]): Shrink[T] =
@@ -41,6 +40,7 @@ private trait ShrinkDeriving:
   // helper for shrinkProduct (runtime-recursion over list with ugly combination of Any and asInstanceOf
   // is a tradeoff with avoiding recursive inlining)
   @tailrec
+  @annotation.nowarn("cat=deprecation")
   private def shrinkTuple[T <: Tuple](
     i: Int,
     size: Int,
@@ -62,6 +62,7 @@ private trait ShrinkDeriving:
       shrinkTuple(i + 1, size, t, newAcc, shrinks.tail)
     }
 
+  @annotation.nowarn("cat=deprecation")
   private inline def shrinkProduct[T](p: Mirror.ProductOf[T]): Shrink[T] =
     val size: Tuple.Size[p.MirroredElemTypes] = constValue
     val shrinks = scala.compiletime.summonAll[Tuple.Map[p.MirroredElemTypes, Shrink]]

--- a/core/src/test/scala/io/github/martinhh/test_classes.scala
+++ b/core/src/test/scala/io/github/martinhh/test_classes.scala
@@ -40,7 +40,7 @@ object SimpleADT:
           )
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   val expectedShrink: Shrink[SimpleADT] =
     Shrink {
       case SimpleCaseObject =>
@@ -136,7 +136,7 @@ object ABC:
       perturb(perturb(seed, ()), ordinal)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   val expectedShrink: Shrink[ABC] =
     Shrink(_ => Stream.empty)
 
@@ -235,7 +235,7 @@ object HasGivenInstances:
   given specialHasGivenInstancesCogen: Cogen[HasGivenInstances] =
     Cogen(_.x + 1)
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   given specialHasGivenInstancesShrink: Shrink[HasGivenInstances] = Shrink { hgi =>
     (1 to 3).map(i => HasGivenInstances(hgi.x + i)).toStream
   }
@@ -330,7 +330,7 @@ object RecursiveList:
           perturbSingletonInSum(1, seed, Nl)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   def expectedShrink[T](using shrinkT: Shrink[T]): Shrink[RecursiveList[T]] =
     Shrink {
       case c: Cns[T] =>
@@ -390,7 +390,7 @@ object NestedSumsRecursiveList:
           perturbSingletonInSum(1, seed, Nl)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   def expectedShrink[T](using shrinkT: Shrink[T]): Shrink[NestedSumsRecursiveList[T]] =
     Shrink {
       case c: Cns[T] =>
@@ -438,7 +438,7 @@ object Maybe:
           perturbSingletonInSum(1, seed, Undefined)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   def expectedShrink[T](shrinkT: => Shrink[T]): Shrink[Maybe[T]] =
     Shrink {
       case d: Defined[T] =>
@@ -487,7 +487,7 @@ object MaybeMaybe:
           perturbSingletonInSum(1, seed, IsNotMaybe)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   def expectedShrink[T](shrinkT: => Shrink[T]): Shrink[MaybeMaybe[T]] =
     Shrink {
       case d: IsMaybe[T] =>
@@ -561,7 +561,7 @@ object DirectRecursion:
           perturbSingletonInSum(1, seed, Stop)
     }
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   def expectedShrink: Shrink[DirectRecursion] =
     Shrink {
       case c: Continue =>
@@ -585,7 +585,7 @@ object SealedDiamond:
   def expectedGen: Gen[SealedDiamond] =
     Gen.oneOf(Gen.const(Bar), Gen.const(Foo))
 
-  @annotation.nowarn("msg=Stream .* is deprecated")
+  @annotation.nowarn("cat=deprecation")
   val expectedShrink: Shrink[SealedDiamond] =
     Shrink { _ =>
       Stream.empty[SealedDiamond]

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
@@ -8,9 +8,9 @@ private type TypedShrink[A] = TypedTypeClass[Shrink, A]
 
 private type UnionTypedShrinks[A] = UnionTypeClasses[TypedShrink, A]
 
-@annotation.nowarn("msg=Stream .* is deprecated")
 private trait UnionShrinks:
 
+  @annotation.nowarn("cat=deprecation")
   private def toShrink[A](uts: UnionTypedShrinks[A]): Shrink[A] =
     Shrink { (a: A) =>
       object TheUnapply:


### PR DESCRIPTION
Use "cat:" instead of "msg:" to suppress
deprecation warnings for Stream.

Also: annotate each affected method,
not whole trait.