### PR TITLE
fix: leaking Shrink-related deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,12 +17,12 @@ inThisBuild(
   )
 )
 
-val productionOnlyOptions = Set("-Xfatal-warnings", "-Wunused:all")
+val productionOnlyOptions = Set("-Wunused:all")
 
 def sharedSettings(scalaV: String = "3.3.5") = Seq(
   scalaVersion := scalaV,
   testFrameworks += new TestFramework("munit.Framework"),
-  scalacOptions ++= productionOnlyOptions.toSeq,
+  scalacOptions ++= productionOnlyOptions.toSeq :+ "-Xfatal-warnings",
   Test / scalacOptions ~= { options =>
     options.filterNot(productionOnlyOptions) :+ "-Wunused:imports"
   },

--- a/core/src/test/scala/io/github/martinhh/test/ShrinkSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/test/ShrinkSuite.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Prop
 import org.scalacheck.Shrink
 
 trait ShrinkSuite extends munit.ScalaCheckSuite:
+  @annotation.nowarn("cat=deprecation")
   protected def equalShrinkValues[T](
     expectedShrink: Shrink[T],
     take: Int = 100

--- a/core/src/test/scala/io/github/martinhh/test_classes.scala
+++ b/core/src/test/scala/io/github/martinhh/test_classes.scala
@@ -210,6 +210,7 @@ object ComplexADTWithNestedMembers:
       AbstractSubClass.SubclassC.expectedGen
     )
 
+  @annotation.nowarn("cat=deprecation")
   val expectedShrink: Shrink[ComplexADTWithNestedMembers] =
     Shrink {
       case AnotherCaseObject =>


### PR DESCRIPTION
Fix deprecations of Stream (as used by Shrink) spreading all over the generated code due to @nowarn having no effect on inlined methods.

(Fixed by hiding the deprecated stuff in a non-inlined helper.)