### PR TITLE
chore: fix typo in `extras.md`

### DIFF
--- a/docs/extras.md
+++ b/docs/extras.md
@@ -6,7 +6,7 @@ You can add it to your sbt project (as test-dependency) as follows:
 
 ```
 libraryDependencies ++= Seq(
-  "io.github.martinhh" %% "scalacheck-derived" % "<version>" % "test"
+  "io.github.martinhh" %% "scalacheck-derived-extras" % "<version>" % "test"
 )
 ```
 


### PR DESCRIPTION
Assuming this is the correct dependency
https://central.sonatype.com/artifact/io.github.martinhh/scalacheck-derived-extras_3