### PR TITLE
ci: bump java to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Scalafmt check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt ci-release


### PR DESCRIPTION
(to re-enable publishing)

Mitigates https://github.com/xerial/sbt-sonatype/issues/518