### PR TITLE
fix: RecursionFallback not in implicit scope

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -12,10 +12,10 @@ import scala.deriving.*
 private sealed trait Gens[T]
 
 private case class SumGens[T](gens: List[SingleGen[T]]) extends Gens[T]:
-  def gen: Gen[T] =
+  inline def gen: Gen[T] =
     Gen.sized { size =>
       if (size <= 0) {
-        SumGens.fallBackGen
+        SumGens.fallBackGen[T]
       } else {
         Gen.resize(size - 1, genOneOf(gens.map(_.gen)))
       }

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -93,6 +93,12 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     equalArbitraryValues(Tree.expectedGen)
   }
 
+  test("with size 0 and RecursionFallback, the fallback is used always") {
+    val fallback: Gen[Tree] = Gen.const(Tree.Leaf(4242))
+    given RecursionFallback[Tree] = RecursionFallback(fallback)
+    equalArbitraryValues(fallback, Parameters.default.withSize(0))
+  }
+
   test("supports RecursionFallback.apply(constValue)") {
     val fallback = Tree.Leaf(42)
     given RecursionFallback[Tree] = RecursionFallback(fallback)

--- a/core/src/test/scala/io/github/martinhh/test_classes.scala
+++ b/core/src/test/scala/io/github/martinhh/test_classes.scala
@@ -613,12 +613,14 @@ object Tree:
   case class Leaf(x: Int) extends Tree
 
   def expectedGenWithFallback(fallback: Gen[Tree]): Gen[Tree] =
-    expectedGenOneOfWithFallback(fallback)(
-      Gen.lzy(
-        expectedGen.flatMap(l => expectedGen.flatMap(m => expectedGen.flatMap(r => Node(l, m, r))))
-      ),
-      arbitrary[Int].map(Leaf.apply)
-    )
+    def gen: Gen[Tree] =
+      expectedGenOneOfWithFallback(fallback)(
+        Gen.lzy(
+          gen.flatMap(l => gen.flatMap(m => gen.flatMap(r => Node(l, m, r))))
+        ),
+        arbitrary[Int].map(Leaf.apply)
+      )
+    gen
 
   def expectedGen: Gen[Tree] = expectedGenWithFallback(Gen.fail)
 


### PR DESCRIPTION
Fixes that `RecursionFallback` instance were never in scope at the place where the derived code would look for them.

Resolves #113 