### PR TITLE
feat: allow custom sum-gen logic

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -163,17 +163,6 @@ trait ArbitraryDeriving[SumConfig[_]]:
         arb
     }
 
-private object ArbitraryDeriving:
-  def apply[Conf[_]](
-    sumGenFactory: [a] => (List[Gen[a]], Option[Conf[a]]) => Gen[a]
-  ): ArbitraryDeriving[Conf] =
-    new ArbitraryDeriving[Conf]:
-      override protected def buildSumGen[A](
-        gens: List[Gen[A]],
-        config: Option[Conf[A]]
-      ): Gen[A] =
-        sumGenFactory(gens, config)
-
 /**
  * Default implementation of derivation of `Arbitrary`s.
  */

--- a/core/src/main/scala/io/github/martinhh/derived/RecursionFallback.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/RecursionFallback.scala
@@ -13,12 +13,12 @@ import org.scalacheck.Gen
  * (e.g. the "leaf" of a recursive tree).
  */
 sealed trait RecursionFallback[A]:
-  private[derived] def gen: Gen[A]
+  def fallbackGen: Gen[A]
 
 object RecursionFallback:
   def apply[A](genA: Gen[A]): RecursionFallback[A] =
     new RecursionFallback[A]:
-      override private[derived] def gen = genA
+      override def fallbackGen: Gen[A] = genA
 
   def apply[A](a: A): RecursionFallback[A] = apply(Gen.const(a))
 

--- a/core/src/main/scala/io/github/martinhh/derived/api.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/api.scala
@@ -7,10 +7,49 @@ import org.scalacheck.Gen
  */
 object arbitrary extends DefaultArbitraryDeriving:
 
+  /**
+   * Contains various factories for customizing derivation.
+   *
+   * Provides support for configuring how the `Gen`-instances of the various subtypes of a sum type (i.e. of a sealed
+   * trait or enum) are combined to a single `Gen`.
+   *
+   * As a simple (and naive) example, if one would want to always put extra weight on the first subtype, one could do
+   * the following:
+   * {{{
+   * import io.github.martinhh.derived.arbitrary.configured
+   *
+   * val customDeriving =
+   * configured.simple(
+   *   [a] =>
+   *     (gens: List[Gen[a]]) => {
+   *       val frequencies = (2 -> gens.head) +: gens.tail.map(g => 1 -> g)
+   *       Gen.frequency(frequencies*)
+   *   }
+   * )
+   * }}}
+   *
+   * Then, one could do the following to have "fully implicit" derivation in scope:
+   * {{{
+   * import customDeriving.given
+   * }}}
+   *
+   * Or, for "explicit" derivation:
+   * {{{
+   * import org.scalacheck.Arbitrary
+   *
+   * given arbExampleADT: Arbitrary[ExampleADT] = customDeriving.deriveArbitrary
+   * }}}
+   */
   object configured:
 
     private sealed trait NoConf[A]
 
+    /**
+     * Factory for creating custom `ArbitraryDeriving` without an additional configuration object.
+     *
+     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
+     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
+     */
     def simple(
       sumGenFactory: [a] => List[Gen[a]] => Gen[a]
     ): ArbitraryDeriving[?] =
@@ -18,11 +57,30 @@ object arbitrary extends DefaultArbitraryDeriving:
         NoConf
       ]([a] => (l: List[Gen[a]], _: Option[NoConf[a]]) => sumGenFactory[a](l))
 
+    /**
+     * Factory for creating custom `ArbitraryDeriving` with support for configuration via `RecursionFallback`.
+     *
+     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
+     *                      The `Option[RecursionFallback[a]]` will be non-empty if a given instance for
+     *                      `RecursionFallback[a]` is in scope where derivation is executed.
+     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
+     */
     def recursionFallback(
       sumGenFactory: [a] => (List[Gen[a]], Option[RecursionFallback[a]]) => Gen[a]
     ): ArbitraryDeriving[RecursionFallback] =
       ArbitraryDeriving[RecursionFallback](sumGenFactory)
 
+    /**
+     * Factory for creating custom `ArbitraryDeriving` with support for a custom configuration type.
+     *
+     * This allows to make derivation for sum types depend on a user-provided configuration type.
+     *
+     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
+     *                      The `Option[SumConfig[a]]` will be non-empty if a given instance for
+     *                      `SumConfig[a]` is in scope where derivation is executed.
+     * @tparam SumConfig The configuration type.
+     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
+     */
     def customConf[SumConfig[_]](
       sumGenFactory: [a] => (List[Gen[a]], Option[SumConfig[a]]) => Gen[a]
     ): ArbitraryDeriving[SumConfig] =

--- a/core/src/main/scala/io/github/martinhh/derived/api.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/api.scala
@@ -20,19 +20,13 @@ object arbitrary extends DefaultArbitraryDeriving:
 
     def recursionFallback(
       sumGenFactory: [a] => (List[Gen[a]], Option[RecursionFallback[a]]) => Gen[a]
-    ): ArbitraryDeriving[?] =
+    ): ArbitraryDeriving[RecursionFallback] =
       ArbitraryDeriving[RecursionFallback](sumGenFactory)
 
     def customConf[SumConfig[_]](
       sumGenFactory: [a] => (List[Gen[a]], Option[SumConfig[a]]) => Gen[a]
-    ): ArbitraryDeriving[?] =
+    ): ArbitraryDeriving[SumConfig] =
       ArbitraryDeriving[SumConfig](sumGenFactory)
-
-    def simpleConf[SumConfig](
-      sumGenFactory: [a] => (List[Gen[a]], Option[SumConfig]) => Gen[a]
-    ): ArbitraryDeriving[?] =
-      type C[A] = SumConfig
-      ArbitraryDeriving[C]([a] => (l: List[Gen[a]], c: Option[C[a]]) => sumGenFactory[a](l, c))
 
 /**
  * Public "API-entry-point" for derivation of scalacheck-typeclass-instances.

--- a/core/src/main/scala/io/github/martinhh/derived/api.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/api.scala
@@ -1,9 +1,15 @@
 package io.github.martinhh.derived
 
+import org.scalacheck.Gen
+
 /**
  * Public "API-entry-point" for derivation of `Arbitrary`-instances.
  */
-object arbitrary extends ArbitraryDeriving
+object arbitrary extends DefaultArbitraryDeriving:
+  def withSumGenFactory(
+    sumGenFactory: [a] => (List[Gen[a]], Option[Gen[a]]) => Gen[a]
+  ): ArbitraryDeriving =
+    ArbitraryDeriving(sumGenFactory)
 
 /**
  * Public "API-entry-point" for derivation of scalacheck-typeclass-instances.
@@ -11,7 +17,7 @@ object arbitrary extends ArbitraryDeriving
  * This does not provide derivation of `Shrink`-instances as that might not always be desired.
  * You can opt in to derivation of `Shrink`-instances via `shrink`.
  */
-object scalacheck extends ArbitraryDeriving with CogenDeriving
+object scalacheck extends DefaultArbitraryDeriving with CogenDeriving
 
 /**
  * Public "API-entry-point" for derivation of `Cogen`-instances.

--- a/core/src/main/scala/io/github/martinhh/derived/api.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/api.scala
@@ -1,90 +1,9 @@
 package io.github.martinhh.derived
 
-import org.scalacheck.Gen
-
 /**
  * Public "API-entry-point" for derivation of `Arbitrary`-instances.
  */
-object arbitrary extends DefaultArbitraryDeriving:
-
-  /**
-   * Contains various factories for customizing derivation.
-   *
-   * Provides support for configuring how the `Gen`-instances of the various subtypes of a sum type (i.e. of a sealed
-   * trait or enum) are combined to a single `Gen`.
-   *
-   * As a simple (and naive) example, if one would want to always put extra weight on the first subtype, one could do
-   * the following:
-   * {{{
-   * import io.github.martinhh.derived.arbitrary.configured
-   *
-   * val customDeriving =
-   * configured.simple(
-   *   [a] =>
-   *     (gens: List[Gen[a]]) => {
-   *       val frequencies = (2 -> gens.head) +: gens.tail.map(g => 1 -> g)
-   *       Gen.frequency(frequencies*)
-   *   }
-   * )
-   * }}}
-   *
-   * Then, one could do the following to have "fully implicit" derivation in scope:
-   * {{{
-   * import customDeriving.given
-   * }}}
-   *
-   * Or, for "explicit" derivation:
-   * {{{
-   * import org.scalacheck.Arbitrary
-   *
-   * given arbExampleADT: Arbitrary[ExampleADT] = customDeriving.deriveArbitrary
-   * }}}
-   */
-  object configured:
-
-    private sealed trait NoConf[A]
-
-    /**
-     * Factory for creating custom `ArbitraryDeriving` without an additional configuration object.
-     *
-     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
-     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
-     */
-    def simple(
-      sumGenFactory: [a] => List[Gen[a]] => Gen[a]
-    ): ArbitraryDeriving[?] =
-      ArbitraryDeriving[
-        NoConf
-      ]([a] => (l: List[Gen[a]], _: Option[NoConf[a]]) => sumGenFactory[a](l))
-
-    /**
-     * Factory for creating custom `ArbitraryDeriving` with support for configuration via `RecursionFallback`.
-     *
-     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
-     *                      The `Option[RecursionFallback[a]]` will be non-empty if a given instance for
-     *                      `RecursionFallback[a]` is in scope where derivation is executed.
-     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
-     */
-    def recursionFallback(
-      sumGenFactory: [a] => (List[Gen[a]], Option[RecursionFallback[a]]) => Gen[a]
-    ): ArbitraryDeriving[RecursionFallback] =
-      ArbitraryDeriving[RecursionFallback](sumGenFactory)
-
-    /**
-     * Factory for creating custom `ArbitraryDeriving` with support for a custom configuration type.
-     *
-     * This allows to make derivation for sum types depend on a user-provided configuration type.
-     *
-     * @param sumGenFactory The logic for combining the `Gen`-instances of the various subtypes of a sum type.
-     *                      The `Option[SumConfig[a]]` will be non-empty if a given instance for
-     *                      `SumConfig[a]` is in scope where derivation is executed.
-     * @tparam SumConfig The configuration type.
-     * @return An object providing the relevant public API for deriving `Arbitrary`-instances.
-     */
-    def customConf[SumConfig[_]](
-      sumGenFactory: [a] => (List[Gen[a]], Option[SumConfig[a]]) => Gen[a]
-    ): ArbitraryDeriving[SumConfig] =
-      ArbitraryDeriving[SumConfig](sumGenFactory)
+object arbitrary extends DefaultArbitraryDeriving
 
 /**
  * Public "API-entry-point" for derivation of scalacheck-typeclass-instances.

--- a/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
@@ -17,21 +17,21 @@ class ConfiguredArbitraryDerivingSuite extends test.ArbitrarySuite:
     def buildSumGen[A](gens: List[Gen[A]], config: Option[Conf[A]]): Gen[A] =
       config.fold(gens.head)(_.select(gens))
 
-  test("configured.customConf via explicit call without conf in scope") {
+  test("custom conf via explicit call without conf in scope") {
     equalArbitraryValues[ABC](Gen.const(ABC.A))(using confExample.deriveArbitrary)
   }
 
-  test("configured.customConf via explicit call with conf in scope") {
+  test("custom conf via explicit call with conf in scope") {
     given Conf[ABC] = lastConf
     equalArbitraryValues[ABC](Gen.const(ABC.C))(using confExample.deriveArbitrary)
   }
 
-  test("configured.customConf via given import without conf in scope") {
+  test("custom conf via given import without conf in scope") {
     import confExample.given
     equalArbitraryValues[ABC](Gen.const(ABC.A))
   }
 
-  test("configured.customConf via given import with conf in scope") {
+  test("custom conf via given import with conf in scope") {
     import confExample.given
     given Conf[ABC] = lastConf
     equalArbitraryValues[ABC](Gen.const(ABC.C))

--- a/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
@@ -1,0 +1,81 @@
+package io.github.martinhh
+
+import io.github.martinhh.ABC.A
+import io.github.martinhh.derived.RecursionFallback
+import org.scalacheck.Gen
+
+class ConfiguredArbitraryDerivingSuite extends test.ArbitrarySuite:
+
+  private val simpleExample =
+    derived.arbitrary.configured.simple([a] => (gens: List[Gen[a]]) => gens.head)
+
+  test("configured.simple via explicit call") {
+    equalArbitraryValues[ABC](Gen.const(ABC.A))(using simpleExample.deriveArbitrary)
+  }
+
+  test("configured.simple via given import") {
+    import simpleExample.given
+    equalArbitraryValues[ABC](Gen.const(ABC.A))
+  }
+
+  private trait Conf[A]:
+    def select(gens: List[Gen[A]]): Gen[A]
+
+  private val lastConf: Conf[ABC] =
+    new Conf:
+      override def select(gens: List[Gen[ABC]]): Gen[ABC] = gens.last
+
+  private val confExample =
+    derived.arbitrary.configured.customConf[
+      Conf
+    ]([a] => (gens: List[Gen[a]], c: Option[Conf[a]]) => c.fold(gens.head)(_.select(gens)))
+
+  test("configured.customConf via explicit call without conf in scope") {
+    equalArbitraryValues[ABC](Gen.const(ABC.A))(using confExample.deriveArbitrary)
+  }
+
+  test("configured.customConf via explicit call with conf in scope") {
+    given Conf[ABC] = lastConf
+    equalArbitraryValues[ABC](Gen.const(ABC.C))(using confExample.deriveArbitrary)
+  }
+
+  test("configured.customConf via given import without conf in scope") {
+    import confExample.given
+    equalArbitraryValues[ABC](Gen.const(ABC.A))
+  }
+
+  test("configured.customConf via given import with conf in scope") {
+    import confExample.given
+    given Conf[ABC] = lastConf
+    equalArbitraryValues[ABC](Gen.const(ABC.C))
+  }
+
+  private val cRecursionFallback: RecursionFallback[ABC] = RecursionFallback(ABC.C)
+
+  private val recursionFallbackExample =
+    derived.arbitrary.configured.recursionFallback(
+      [a] =>
+        (gens: List[Gen[a]], rf: Option[RecursionFallback[a]]) => rf.fold(gens.head)(_.fallbackGen)
+    )
+
+  test("configured.recursionFallback via explicit call without RecursionFallback in scope") {
+    equalArbitraryValues[ABC](Gen.const(ABC.A))(using recursionFallbackExample.deriveArbitrary)
+  }
+
+  test("configured.recursionFallback via explicit call with RecursionFallback in scope") {
+    given RecursionFallback[ABC] = cRecursionFallback
+
+    equalArbitraryValues[ABC](Gen.const(ABC.C))(using recursionFallbackExample.deriveArbitrary)
+  }
+
+  test("configured.recursionFallback via given import without RecursionFallback in scope") {
+    import recursionFallbackExample.given
+    equalArbitraryValues[ABC](Gen.const(ABC.A))
+  }
+
+  test("configured.recursionFallback via given import with RecursionFallback in scope") {
+    import recursionFallbackExample.given
+    given RecursionFallback[ABC] = cRecursionFallback
+
+    equalArbitraryValues[ABC](Gen.const(ABC.C))
+  }

--- a/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ConfiguredArbitraryDerivingSuite.scala
@@ -1,22 +1,10 @@
 package io.github.martinhh
 
 import io.github.martinhh.ABC.A
-import io.github.martinhh.derived.RecursionFallback
+import io.github.martinhh.derived.ArbitraryDeriving
 import org.scalacheck.Gen
 
 class ConfiguredArbitraryDerivingSuite extends test.ArbitrarySuite:
-
-  private val simpleExample =
-    derived.arbitrary.configured.simple([a] => (gens: List[Gen[a]]) => gens.head)
-
-  test("configured.simple via explicit call") {
-    equalArbitraryValues[ABC](Gen.const(ABC.A))(using simpleExample.deriveArbitrary)
-  }
-
-  test("configured.simple via given import") {
-    import simpleExample.given
-    equalArbitraryValues[ABC](Gen.const(ABC.A))
-  }
 
   private trait Conf[A]:
     def select(gens: List[Gen[A]]): Gen[A]
@@ -25,10 +13,9 @@ class ConfiguredArbitraryDerivingSuite extends test.ArbitrarySuite:
     new Conf:
       override def select(gens: List[Gen[ABC]]): Gen[ABC] = gens.last
 
-  private val confExample =
-    derived.arbitrary.configured.customConf[
-      Conf
-    ]([a] => (gens: List[Gen[a]], c: Option[Conf[a]]) => c.fold(gens.head)(_.select(gens)))
+  private object confExample extends ArbitraryDeriving[Conf]:
+    def buildSumGen[A](gens: List[Gen[A]], config: Option[Conf[A]]): Gen[A] =
+      config.fold(gens.head)(_.select(gens))
 
   test("configured.customConf via explicit call without conf in scope") {
     equalArbitraryValues[ABC](Gen.const(ABC.A))(using confExample.deriveArbitrary)
@@ -47,35 +34,5 @@ class ConfiguredArbitraryDerivingSuite extends test.ArbitrarySuite:
   test("configured.customConf via given import with conf in scope") {
     import confExample.given
     given Conf[ABC] = lastConf
-    equalArbitraryValues[ABC](Gen.const(ABC.C))
-  }
-
-  private val cRecursionFallback: RecursionFallback[ABC] = RecursionFallback(ABC.C)
-
-  private val recursionFallbackExample =
-    derived.arbitrary.configured.recursionFallback(
-      [a] =>
-        (gens: List[Gen[a]], rf: Option[RecursionFallback[a]]) => rf.fold(gens.head)(_.fallbackGen)
-    )
-
-  test("configured.recursionFallback via explicit call without RecursionFallback in scope") {
-    equalArbitraryValues[ABC](Gen.const(ABC.A))(using recursionFallbackExample.deriveArbitrary)
-  }
-
-  test("configured.recursionFallback via explicit call with RecursionFallback in scope") {
-    given RecursionFallback[ABC] = cRecursionFallback
-
-    equalArbitraryValues[ABC](Gen.const(ABC.C))(using recursionFallbackExample.deriveArbitrary)
-  }
-
-  test("configured.recursionFallback via given import without RecursionFallback in scope") {
-    import recursionFallbackExample.given
-    equalArbitraryValues[ABC](Gen.const(ABC.A))
-  }
-
-  test("configured.recursionFallback via given import with RecursionFallback in scope") {
-    import recursionFallbackExample.given
-    given RecursionFallback[ABC] = cRecursionFallback
-
     equalArbitraryValues[ABC](Gen.const(ABC.C))
   }


### PR DESCRIPTION
Allow to override the logic for combining the `Gen` instances for a sum-type so that users can override the default `Gen.sized`-based solution.

Closes #108 (as that scenario could now be mitigated via a customized solutions).