### PR TITLE
feat: deriveArbitraryShallow

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -150,7 +150,9 @@ trait ArbitraryDeriving[SumConfig[_]]:
     import scalacheck.anyGivenArbitrary
     inline m match
       case s: Mirror.SumOf[T] =>
-        Arbitrary(sumGen(Gens.sumInstance(s).gens))
+        // given to support recursion (without falling back to the above import
+        given a: Arbitrary[T] = Arbitrary(sumGen(Gens.sumInstance(s).gens))
+        a
       case p: Mirror.ProductOf[T] =>
         Arbitrary(Gens.productGen(p))
 

--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -125,6 +125,13 @@ trait ArbitraryDeriving[SumConfig[_]]:
       case _                => None
     }
 
+  final inline def deriveArbitraryShallow[T](using m: Mirror.Of[T]): Arbitrary[T] =
+    inline m match
+      case s: Mirror.SumOf[T] =>
+        Arbitrary(sumGen(Gens.sumInstance(s).gens))
+      case p: Mirror.ProductOf[T] =>
+        Arbitrary(Gens.productGen(p))
+
   /**
    * Derives an `Arbitrary[T]`, ignoring any `given Arbitrary[T]` that is already in scope.
    *

--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -128,7 +128,9 @@ trait ArbitraryDeriving[SumConfig[_]]:
   final inline def deriveArbitraryShallow[T](using m: Mirror.Of[T]): Arbitrary[T] =
     inline m match
       case s: Mirror.SumOf[T] =>
-        Arbitrary(sumGen(Gens.sumInstance(s).gens))
+        // given to support recursion
+        given a: Arbitrary[T] = Arbitrary(sumGen(Gens.sumInstance(s).gens))
+        a
       case p: Mirror.ProductOf[T] =>
         Arbitrary(Gens.productGen(p))
 

--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -138,7 +138,7 @@ trait ArbitraryDeriving[SumConfig[_]]:
    *   case class Point(x: Double, y: Double)
    *   given Arbitrary[Point] = deriveArbitraryShallow
    * }}}
-   * 
+   *
    * The following however would fail:
    * {{{
    *   case class Foo(x: Int)
@@ -158,7 +158,7 @@ trait ArbitraryDeriving[SumConfig[_]]:
 
   /**
    * Derives an `Arbitrary[T]`, ignoring any `given Arbitrary[T]` that is already in scope.
-   * 
+   *
    * Note that this will recursively derive any missing `Arbitrary`-instances for any members/subtypes
    * of `T` (unless such instances are already available in implicit scope).
    *

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -52,9 +52,7 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     )
   }
 
-  test(
-    "deriveArbitraryShallow succeeds for case class containing another case class if an instance for that is available"
-  ) {
+  test("deriveArbitraryShallow succeeds simple case class") {
     given Arbitrary[SimpleCaseClass] = Arbitrary(SimpleCaseClass.expectedGen)
     equalArbitraryValues(AbstractSubClass.SubclassA.expectedGen)(
       using derived.arbitrary.deriveArbitraryShallow
@@ -98,6 +96,24 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
       )
     equalArbitraryValues(expectedGen)(
       using derived.arbitrary.deriveArbitraryShallow[Maybe[Foo]]
+    )
+  }
+
+  test("deriveArbitraryShallow supports recursive sum types") {
+    equalArbitraryValues(Tree.expectedGen)(
+      using derived.arbitrary.deriveArbitraryShallow
+    )
+  }
+
+  test("deriveArbitraryShallow supports nested sealed traits (with diamond inheritance)") {
+    equalArbitraryValues(SealedDiamond.expectedGen)(
+      using derived.arbitrary.deriveArbitraryShallow
+    )
+  }
+
+  test("deriveArbitraryShallow supports nested sealed traits (with recursion)") {
+    equalArbitraryValues(NestedSumsRecursiveList.expectedGen[Int])(
+      using derived.arbitrary.deriveArbitraryShallow
     )
   }
 

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -34,6 +34,73 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     )
   }
 
+  test(
+    "deriveArbitraryShallow succeeds for case class containing another case class if an instance for that is available"
+  ) {
+    equalArbitraryValues(SimpleCaseClass.expectedGen)(
+      using derived.arbitrary.deriveArbitraryShallow
+    )
+  }
+
+  test("deriveArbitraryShallow fails for case class containing another case class") {
+    val error: String =
+      compileErrors("derived.arbitrary.deriveArbitraryShallow[AbstractSubClass.SubclassA]")
+    assert(
+      error.contains(
+        "No given instance of type org.scalacheck.Arbitrary[io.github.martinhh.SimpleCaseClass] was found."
+      )
+    )
+  }
+
+  test(
+    "deriveArbitraryShallow succeeds for case class containing another case class if an instance for that is available"
+  ) {
+    given Arbitrary[SimpleCaseClass] = Arbitrary(SimpleCaseClass.expectedGen)
+    equalArbitraryValues(AbstractSubClass.SubclassA.expectedGen)(
+      using derived.arbitrary.deriveArbitraryShallow
+    )
+  }
+
+  test("deriveArbitraryShallow succeeds for ADT if subclasses are derivable via deriveShallow") {
+    equalArbitraryValues(Maybe.expectedGen[Int])(
+      using derived.arbitrary.deriveArbitraryShallow[Maybe[Int]]
+    )
+  }
+
+  test("deriveArbitraryShallow fails for ADT if a subclass is not derivable via deriveShallow") {
+    val error: String =
+      compileErrors("derived.arbitrary.deriveArbitraryShallow[Maybe[SimpleCaseClass]]")
+    assert(
+      error.contains(
+        "Derivation failed. No given instance of type Summoner[io.github.martinhh.Maybe.Defined[io.github.martinhh.SimpleCaseClass]] was found." +
+          " This is most likely due to no Arbitrary[io.github.martinhh.Maybe.Defined[io.github.martinhh.SimpleCaseClass]] being available."
+      )
+    )
+  }
+
+  test(
+    "deriveArbitraryShallow succeeds for ADT if a subclass is made derivable via deriveShallow by required instances in scope"
+  ) {
+    given Arbitrary[SimpleCaseClass] = Arbitrary(SimpleCaseClass.expectedGen)
+    equalArbitraryValues(Maybe.expectedGen[SimpleCaseClass])(
+      using derived.arbitrary.deriveArbitraryShallow[Maybe[SimpleCaseClass]]
+    )
+  }
+
+  test("deriveArbitraryShallow prefers existing instance for ADT-subtypes") {
+    case class Foo(x: Int)
+    val customGen: Gen[Maybe.Defined[Foo]] = Gen.const(Maybe.Defined(Foo(35)))
+    given Arbitrary[Maybe.Defined[Foo]] = Arbitrary(customGen)
+    val expectedGen: Gen[Maybe[Foo]] =
+      expectedGenOneOf(
+        customGen,
+        Gen.const(Maybe.Undefined)
+      )
+    equalArbitraryValues(expectedGen)(
+      using derived.arbitrary.deriveArbitraryShallow[Maybe[Foo]]
+    )
+  }
+
   import io.github.martinhh.derived.arbitrary.given
 
   test("Generates same values as non-derived Gen (for simple case class)") {

--- a/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
+++ b/core/src/test/scala/io/github/martinhh/ArbitraryDerivingSuite.scala
@@ -34,9 +34,7 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     )
   }
 
-  test(
-    "deriveArbitraryShallow succeeds for case class containing another case class if an instance for that is available"
-  ) {
+  test("deriveArbitraryShallow succeeds for simple case class") {
     equalArbitraryValues(SimpleCaseClass.expectedGen)(
       using derived.arbitrary.deriveArbitraryShallow
     )
@@ -52,7 +50,9 @@ class ArbitraryDerivingSuite extends test.ArbitrarySuite:
     )
   }
 
-  test("deriveArbitraryShallow succeeds simple case class") {
+  test(
+    "deriveArbitraryShallow succeeds for case class containing another case class if an instance for that is available"
+  ) {
     given Arbitrary[SimpleCaseClass] = Arbitrary(SimpleCaseClass.expectedGen)
     equalArbitraryValues(AbstractSubClass.SubclassA.expectedGen)(
       using derived.arbitrary.deriveArbitraryShallow


### PR DESCRIPTION
Alternative derivation API where derivation will abort if instances for members of product types
are not available (instead of deriving them).

(However: it will derive the subtypes of a sum type if that is possible without deriving members of those.)

Not exactly what was requested in #133 , but it goes in that direction.