### PR TITLE
chore: disallow inheritance of APIs

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -101,7 +101,7 @@ private object Gens:
  *                   subtypes of a sum type (i.e. of a sealed trait or enum) are combined to a single `Gen`. See
  *                   `buildSumGen` for its usage.
  */
-trait ArbitraryDeriving[SumConfig[_]]:
+private[martinhh] trait ArbitraryDeriving[SumConfig[_]]:
 
   /**
    * The logic for combining the `Gen`-instances of the various subtypes of a sum type (i.e. of a sealed trait or enum).
@@ -210,7 +210,7 @@ trait ArbitraryDeriving[SumConfig[_]]:
 /**
  * Default implementation of derivation of `Arbitrary`s.
  */
-trait DefaultArbitraryDeriving extends ArbitraryDeriving[RecursionFallback]:
+private trait DefaultArbitraryDeriving extends ArbitraryDeriving[RecursionFallback]:
 
   override final protected def buildSumGen[A](
     gens: List[Gen[A]],

--- a/core/src/main/scala/io/github/martinhh/derived/CogenDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/CogenDeriving.scala
@@ -25,7 +25,7 @@ object CogenSumInstanceSummoner
         cogen.deriveCogen[Elem](using m)
     }
 
-trait CogenDeriving:
+private trait CogenDeriving:
 
   private inline def cogenSum[T](s: Mirror.SumOf[T]): Cogen[T] =
     @implicitNotFound(

--- a/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
@@ -27,7 +27,7 @@ private object ShrinkSumInstanceSummoner
         shrink.deriveShrink[Elem](using m)
     }
 
-trait ShrinkDeriving:
+private trait ShrinkDeriving:
 
   private inline def shrinkSum[T](s: Mirror.SumOf[T]): Shrink[T] =
     // note that this will most certainly never come to effect due to `org.scalacheck.Shrink.shrinkAny]`

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralArbitraries.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralArbitraries.scala
@@ -5,6 +5,6 @@ import org.scalacheck.Gen
 
 import scala.compiletime.summonInline
 
-trait LiteralArbitraries:
+private trait LiteralArbitraries:
 
   final given arbLiteral[A](using v: ValueOf[A]): Arbitrary[A] = Arbitrary(Gen.const(v.value))

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralCogens.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralCogens.scala
@@ -2,6 +2,6 @@ package io.github.martinhh.derived.extras.literal
 
 import org.scalacheck.Cogen
 
-trait LiteralCogens:
+private trait LiteralCogens:
 
   final given cogenLiteral[A: ValueOf]: Cogen[A] = Cogen(_ => 0L)

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionArbitraries.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionArbitraries.scala
@@ -13,7 +13,7 @@ private type UnionArbs[A] = UnionTypeClasses[Arbitrary, A]
 private def toGen[A](utc: UnionArbs[A]): Gen[A] =
   genOneOf(utc.instances.map(_.instance.arbitrary))
 
-trait UnionArbitraries:
+private trait UnionArbitraries:
 
   transparent inline final given unionGensMacro[X]: UnionArbs[X] =
     io.github.martinhh.derived.extras.union.unionTypedGensMacro[X]

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionCogens.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionCogens.scala
@@ -22,7 +22,7 @@ private def toCogen[A](utc: UnionTypedCogens[A]): Cogen[A] =
     seedOpt.get
   }
 
-trait UnionCogens:
+private trait UnionCogens:
   transparent inline final given unionTypedCogensMacro[X]: UnionTypedCogens[X] =
     io.github.martinhh.derived.extras.union.unionTypedCogensMacro
 

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
@@ -8,7 +8,7 @@ private type TypedShrink[A] = TypedTypeClass[Shrink, A]
 
 private type UnionTypedShrinks[A] = UnionTypeClasses[TypedShrink, A]
 
-trait UnionShrinks:
+private trait UnionShrinks:
 
   @annotation.nowarn("cat=deprecation")
   private def toShrink[A](uts: UnionTypedShrinks[A]): Shrink[A] =


### PR DESCRIPTION
Reverting #122 and the similar changes from #121 for now as there is still at least one bug in the mechanism introduced in #121 - so I'd rather not make it public in the upcoming release (and just making some of the traits public but not the main one seems inconsistent).