### PR TITLE
ci: fix native builds on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up Clang
+        # workaround for https://github.com/actions/runner-images/issues/12435
+        if: runner.os == 'Windows'
+        uses: egor-tensin/setup-clang@v1.4
+        with:
+          version: 19.1.7
+          platform: x64
       - name: restore cache
         uses: coursier/cache-action@v6
       - name: setup sbt


### PR DESCRIPTION
workaround for https://github.com/actions/runner-images/issues/12435
 (which causes compilation errors for scala native on windows machines).