### PR TITLE
feat: allow inheritance of APIs

### DIFF
--- a/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ArbitraryDeriving.scala
@@ -132,7 +132,7 @@ private object Gens:
  *                   subtypes of a sum type (i.e. of a sealed trait or enum) are combined to a single `Gen`. See
  *                   `buildSumGen` for its usage.
  */
-private[martinhh] trait ArbitraryDeriving[SumConfig[_]]:
+trait ArbitraryDeriving[SumConfig[_]]:
   self =>
 
   /**
@@ -282,7 +282,7 @@ private[martinhh] trait ArbitraryDeriving[SumConfig[_]]:
 /**
  * Default implementation of derivation of `Arbitrary`s.
  */
-private trait DefaultArbitraryDeriving extends ArbitraryDeriving[RecursionFallback]:
+trait DefaultArbitraryDeriving extends ArbitraryDeriving[RecursionFallback]:
 
   override final protected def buildSumGen[A](
     gens: List[Gen[A]],

--- a/core/src/main/scala/io/github/martinhh/derived/CogenDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/CogenDeriving.scala
@@ -96,7 +96,7 @@ private[derived] object CogenDeriving:
       .asInstanceOf[Cogen[p.MirroredElemTypes]]
     cogenTuple.contramap[T](productToMirroredElemTypes(p)(_))
 
-private trait CogenDeriving:
+trait CogenDeriving:
   self =>
 
   /**

--- a/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
+++ b/core/src/main/scala/io/github/martinhh/derived/ShrinkDeriving.scala
@@ -27,7 +27,7 @@ private object ShrinkSumInstanceSummoner
         shrink.deriveShrink[Elem](using m)
     }
 
-private trait ShrinkDeriving:
+trait ShrinkDeriving:
   self =>
 
   private inline def shrinkSum[T](s: Mirror.SumOf[T]): Shrink[T] =

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralArbitraries.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralArbitraries.scala
@@ -5,6 +5,6 @@ import org.scalacheck.Gen
 
 import scala.compiletime.summonInline
 
-private trait LiteralArbitraries:
+trait LiteralArbitraries:
 
   final given arbLiteral[A](using v: ValueOf[A]): Arbitrary[A] = Arbitrary(Gen.const(v.value))

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralCogens.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/literal/LiteralCogens.scala
@@ -2,6 +2,6 @@ package io.github.martinhh.derived.extras.literal
 
 import org.scalacheck.Cogen
 
-private trait LiteralCogens:
+trait LiteralCogens:
 
   final given cogenLiteral[A: ValueOf]: Cogen[A] = Cogen(_ => 0L)

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionArbitraries.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionArbitraries.scala
@@ -13,7 +13,7 @@ private type UnionArbs[A] = UnionTypeClasses[Arbitrary, A]
 private def toGen[A](utc: UnionArbs[A]): Gen[A] =
   genOneOf(utc.instances.map(_.instance.arbitrary))
 
-private trait UnionArbitraries:
+trait UnionArbitraries:
 
   transparent inline final given unionGensMacro[X]: UnionArbs[X] =
     io.github.martinhh.derived.extras.union.unionTypedGensMacro[X]

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionCogens.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionCogens.scala
@@ -22,7 +22,7 @@ private def toCogen[A](utc: UnionTypedCogens[A]): Cogen[A] =
     seedOpt.get
   }
 
-private trait UnionCogens:
+trait UnionCogens:
   transparent inline final given unionTypedCogensMacro[X]: UnionTypedCogens[X] =
     io.github.martinhh.derived.extras.union.unionTypedCogensMacro
 

--- a/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
+++ b/extras/src/main/scala/io/github/martinhh/derived/extras/union/UnionShrinks.scala
@@ -8,7 +8,7 @@ private type TypedShrink[A] = TypedTypeClass[Shrink, A]
 
 private type UnionTypedShrinks[A] = UnionTypeClasses[TypedShrink, A]
 
-private trait UnionShrinks:
+trait UnionShrinks:
 
   @annotation.nowarn("cat=deprecation")
   private def toShrink[A](uts: UnionTypedShrinks[A]): Shrink[A] =


### PR DESCRIPTION
Make the various "API-traits" public so one can mix them into test suites etc.

This was already implemented in #122, but then reverted before the 0.9.0 release in #140 to exclude it from that release in order to fix a bug that affected "configured derivation for sum-types" (which depends on inheritance). That bug was not fixed (#150), so inheritance and thus configured derivation (#121) can be made public in the next release.