### PR TITLE
docs: remove badge version param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scalacheck-derived
 
-[![CI](https://github.com/martinhh/scalacheck-derived/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MartinHH/scalacheck-derived/actions/workflows/ci.yml?query=branch%3Amain) [![Maven Central](https://maven-badges.sml.io/sonatype-central/io.github.martinhh/scalacheck-derived_3/badge.svg?version=0.10.0)](https://maven-badges.sml.io/sonatype-central/io.github.martinhh/scalacheck-derived_3?version=0.10.0)
+[![CI](https://github.com/martinhh/scalacheck-derived/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MartinHH/scalacheck-derived/actions/workflows/ci.yml?query=branch%3Amain) [![Maven Central](https://maven-badges.sml.io/sonatype-central/io.github.martinhh/scalacheck-derived_3/badge.svg)](https://maven-badges.sml.io/sonatype-central/io.github.martinhh/scalacheck-derived_3)
 
 Automatic derivation of [scalacheck](https://github.com/typelevel/scalacheck) `Arbitrary` (and `Cogen` and `Shrink`)
 instances for Scala 3.


### PR DESCRIPTION
https://github.com/softwaremill/maven-badges/issues/1009 has been fixed, so no more need for a hard-coded version.